### PR TITLE
Preserve INI comments on direct-access writes with regression tests a…

### DIFF
--- a/doc/bc/6.0/eZINI_PRESERVES_COMMENTS.md
+++ b/doc/bc/6.0/eZINI_PRESERVES_COMMENTS.md
@@ -1,0 +1,133 @@
+# eZINI Preserves Comments on Save
+
+## TL;DR
+
+`eZINI` now uses a round-trip save path for direct-access INI writes to preserve existing comments and structure instead of rewriting the whole file from normalized arrays.
+
+Legacy full rewrite is still available as fallback when round-trip cannot be applied safely.
+
+## Problem
+
+Historically, `eZINI` parse/save behavior dropped comments and formatting because:
+
+- parser ignored full-line comments (`# ...`)
+- parser stripped inline comment tails (`## ...`)
+- writer always serialized from `BlockValues`
+
+In real admin flows (for example extension activation), this caused `settings/override/site.ini.append.php` to lose much of its original layout and comments.
+
+## What Was Implemented
+
+Round-trip support was added in [lib/ezutils/classes/ezini.php](lib/ezutils/classes/ezini.php):
+
+- capture original file lines and parse line indexes for sections/settings
+- patch only the targeted keys/sections during save
+- preserve untouched lines, comments, and spacing
+
+## Follow-up Fixes After Real-World Validation
+
+Two additional bugs were fixed:
+
+1. Cache-loaded direct-access instances:
+- if values were restored from INI cache, parse-time snapshot data could be missing
+- save now lazily loads source from disk before patching
+
+2. Section and line-replacement correctness:
+- comment-only / empty sections are now tracked during parse and preserved
+- variable replacement now removes exact indexed lines (not contiguous spans), preventing unrelated line loss
+
+## Behavior
+
+Round-trip save is attempted when:
+
+1. direct-access mode is used
+2. source lines can be resolved for the target file
+3. patching is safe for current operation
+
+When active, save can:
+
+- retain existing comments and blank lines
+- update changed values in place
+- append new keys in the correct section
+- remove deleted keys/sections on full save (`$onlyModified = false`)
+
+Fallback behavior:
+
+- if round-trip prerequisites are not met, legacy serializer is used
+
+## Scope and BC
+
+- Scope: direct-access saves
+- API compatibility: unchanged (constructor/signatures/callers do not change)
+- BC: backward compatible at API level, improved output preservation behavior
+
+## Tests
+
+Test file: [tests/tests/lib/ezutils/ezini_test.php](tests/tests/lib/ezutils/ezini_test.php)
+
+Added/expanded round-trip regressions:
+
+1. `testSavePreservesCommentsInDirectAccessMode`
+2. `testSaveAppendsNewSettingWithoutDroppingComments`
+3. `testSaveRemovesDeletedSettingAndKeepsSectionComments`
+4. `testSavePreservesCommentsWhenLoadedFromCache`
+5. `testSaveRetainsRealSiteIniStructureWhenUpdatingExtensions`
+6. `testSaveRetainsCurrentSiteIniAppendOutsideExtensionSettings`
+
+Also included:
+
+- temporary fixture cleanup helper
+- compatibility alias class (`ezini_test extends eZINITest`) for filename-based runners
+
+## Commands and Current Results
+
+Syntax checks:
+
+```bash
+php -l lib/ezutils/classes/ezini.php
+php -l tests/tests/lib/ezutils/ezini_test.php
+```
+
+Result:
+
+- no syntax errors
+
+Focused regression subset:
+
+```bash
+./vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/tests/lib/ezutils/ezini_test.php --filter 'testSave(RetainsCurrentSiteIniAppendOutsideExtensionSettings|RetainsRealSiteIniStructureWhenUpdatingExtensions|PreservesCommentsWhenLoadedFromCache)$'
+```
+
+Result:
+
+- OK (3 tests, 17 assertions)
+
+Expanded round-trip subset:
+
+```bash
+./vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/tests/lib/ezutils/ezini_test.php --filter 'testSave(PreservesCommentsInDirectAccessMode|AppendsNewSettingWithoutDroppingComments|RemovesDeletedSettingAndKeepsSectionComments|PreservesCommentsWhenLoadedFromCache|RetainsRealSiteIniStructureWhenUpdatingExtensions)$'
+```
+
+Result:
+
+- OK (5 tests, 29 assertions)
+
+Full eZINI test file:
+
+```bash
+./vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/tests/lib/ezutils/ezini_test.php
+```
+
+Result:
+
+- OK (11 tests, 50 assertions)
+
+## Rollout Notes
+
+No config/schema migration is required.
+
+Recommended rollout:
+
+1. Deploy code update.
+2. Run the full `ezini_test.php` file.
+3. Verify admin write flows in staging for INI files with comments (extensions, toolbar/menu settings, etc.).

--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -747,6 +747,11 @@ class eZINI
         if ( $reset )
             $this->reset();
 
+        if ( !$placement )
+        {
+            $this->LastParsedInputFiles = $inputFiles;
+        }
+
         foreach ( $inputFiles as $inputFile )
         {
             if ( file_exists( $inputFile ) )
@@ -814,6 +819,11 @@ class eZINI
         else
             $this->Codec = null;
 
+        if ( !$placement )
+        {
+            $this->RoundTripData[$this->normalizePathForRoundTrip( $file )] = $this->buildRoundTripData( $contents );
+        }
+
         foreach ( explode( "\n", $contents ) as $line )
         {
             if ( $line == '' or $line[0] == '#' )
@@ -827,6 +837,18 @@ class eZINI
             {
                 $newBlockName = trim( $newBlockNameArray[1] );
                 $currentBlock = $newBlockName;
+
+                if ( $placement )
+                {
+                    if ( !isset( $this->BlockValuesPlacement[$currentBlock] ) )
+                        $this->BlockValuesPlacement[$currentBlock] = array();
+                }
+                else
+                {
+                    if ( !isset( $this->BlockValues[$currentBlock] ) )
+                        $this->BlockValues[$currentBlock] = array();
+                }
+
                 continue;
             }
 
@@ -978,128 +1000,141 @@ class eZINI
         $originalFilePath = eZDir::path( array_merge( $pathArray, array( $originalFileName ) ) );
         $backupFilePath = eZDir::path( array_merge( $pathArray, array( $backupFileName ) ) );
 
-        $fp = @fopen( $filePath, "w+");
-        if ( !$fp )
-        {
-            eZDebug::writeError( "Failed opening file '$filePath' for writing", __METHOD__ );
-            return false;
-        }
-        $writeOK = true;
-        $written = 0;
+        $roundTripContent = $this->buildRoundTripSaveContent( $originalFilePath, $onlyModified, $resetArrays );
 
-        $charset = $this->Codec ? $this->Codec->RequestedOutputCharsetCode : $this->Charset;
-        if ( $encapsulateInPHP )
+        if ( $roundTripContent !== false )
         {
-            $written = fwrite( $fp, "<?php /* #?ini charset=\"$charset\"?$lineSeparator$lineSeparator" );
+            if ( file_put_contents( $filePath, $roundTripContent ) === false )
+            {
+                eZDebug::writeError( "Failed opening file '$filePath' for writing", __METHOD__ );
+                return false;
+            }
         }
         else
         {
-            $written = fwrite( $fp, "#?ini charset=\"$charset\"?$lineSeparator$lineSeparator" );
-        }
-
-        if ( $written === false )
-            $writeOK = false;
-        $i = 0;
-        if ( $writeOK )
-        {
-            foreach( array_keys( $this->BlockValues ) as $blockName )
+            $fp = @fopen( $filePath, "w+");
+            if ( !$fp )
             {
-                if ( $onlyModified )
-                {
-                    $groupHasModified = false;
-                    if ( isset( $this->ModifiedBlockValues[$blockName] ) )
-                    {
-                        foreach ( $this->ModifiedBlockValues[$blockName] as $modifiedValue )
-                        {
-                            if ( $modifiedValue )
-                                $groupHasModified = true;
-                        }
-                    }
-                    if ( !$groupHasModified )
-                        continue;
-                }
-                $written = 0;
-                if ( $i > 0 )
-                    $written = fwrite( $fp, "$lineSeparator" );
-                if ( $written === false )
-                {
-                    $writeOK = false;
-                    break;
-                }
-                $written = fwrite( $fp, "[$blockName]$lineSeparator" );
-                if ( $written === false )
-                {
-                    $writeOK = false;
-                    break;
-                }
-                foreach( array_keys( $this->BlockValues[$blockName] ) as $blockVariable )
+                eZDebug::writeError( "Failed opening file '$filePath' for writing", __METHOD__ );
+                return false;
+            }
+            $writeOK = true;
+            $written = 0;
+
+            $charset = $this->Codec ? $this->Codec->RequestedOutputCharsetCode : $this->Charset;
+            if ( $encapsulateInPHP )
+            {
+                $written = fwrite( $fp, "<?php /* #?ini charset=\"$charset\"?$lineSeparator$lineSeparator" );
+            }
+            else
+            {
+                $written = fwrite( $fp, "#?ini charset=\"$charset\"?$lineSeparator$lineSeparator" );
+            }
+
+            if ( $written === false )
+                $writeOK = false;
+            $i = 0;
+            if ( $writeOK )
+            {
+                foreach( array_keys( $this->BlockValues ) as $blockName )
                 {
                     if ( $onlyModified )
                     {
-                        if ( !isset( $this->ModifiedBlockValues[$blockName][$blockVariable] ) or
-                             !$this->ModifiedBlockValues[$blockName][$blockVariable] )
-                            continue;
-                    }
-                    $varKey = $blockVariable;
-                    $varValue = $this->BlockValues[$blockName][$blockVariable];
-                    if ( is_array( $varValue ) )
-                    {
-                        if ( count( $varValue ) > 0 )
+                        $groupHasModified = false;
+                        if ( isset( $this->ModifiedBlockValues[$blockName] ) )
                         {
-                            $customResetArray = ( isset( $this->BlockValues[$blockName]['ResetArrays'] ) and
-                                                  $this->BlockValues[$blockName]['ResetArrays'] == 'false' )
-                                                ? true
-                                                : false;
-                            if ( $resetArrays and !$customResetArray )
-                                $written = fwrite( $fp, "$varKey" . "[]$lineSeparator" );
-                            foreach ( $varValue as $varArrayKey => $varArrayValue )
+                            foreach ( $this->ModifiedBlockValues[$blockName] as $modifiedValue )
                             {
-                                if ( is_string( $varArrayKey ) )
-                                    $written = fwrite( $fp, "$varKey" . "[$varArrayKey]=$varArrayValue$lineSeparator" );
-                                else
-                                {
-                                    if ( $varArrayValue == NULL )
-                                        $written = fwrite( $fp, "$varKey" . "[]$lineSeparator" );
-                                    else
-                                        $written = fwrite( $fp, "$varKey" . "[]=$varArrayValue$lineSeparator" );
-                                }
-                                if ( $written === false )
-                                    break;
+                                if ( $modifiedValue )
+                                    $groupHasModified = true;
                             }
                         }
-                        else
-                            $written = fwrite( $fp, "$varKey" . "[]$lineSeparator" );
+                        if ( !$groupHasModified )
+                            continue;
                     }
-                    else
-                    {
-                        $written = fwrite( $fp, "$varKey=$varValue$lineSeparator" );
-                    }
+                    $written = 0;
+                    if ( $i > 0 )
+                        $written = fwrite( $fp, "$lineSeparator" );
                     if ( $written === false )
                     {
                         $writeOK = false;
                         break;
                     }
+                    $written = fwrite( $fp, "[$blockName]$lineSeparator" );
+                    if ( $written === false )
+                    {
+                        $writeOK = false;
+                        break;
+                    }
+                    foreach( array_keys( $this->BlockValues[$blockName] ) as $blockVariable )
+                    {
+                        if ( $onlyModified )
+                        {
+                            if ( !isset( $this->ModifiedBlockValues[$blockName][$blockVariable] ) or
+                                 !$this->ModifiedBlockValues[$blockName][$blockVariable] )
+                                continue;
+                        }
+                        $varKey = $blockVariable;
+                        $varValue = $this->BlockValues[$blockName][$blockVariable];
+                        if ( is_array( $varValue ) )
+                        {
+                            if ( count( $varValue ) > 0 )
+                            {
+                                $customResetArray = ( isset( $this->BlockValues[$blockName]['ResetArrays'] ) and
+                                                      $this->BlockValues[$blockName]['ResetArrays'] == 'false' )
+                                                    ? true
+                                                    : false;
+                                if ( $resetArrays and !$customResetArray )
+                                    $written = fwrite( $fp, "$varKey" . "[]$lineSeparator" );
+                                foreach ( $varValue as $varArrayKey => $varArrayValue )
+                                {
+                                    if ( is_string( $varArrayKey ) )
+                                        $written = fwrite( $fp, "$varKey" . "[$varArrayKey]=$varArrayValue$lineSeparator" );
+                                    else
+                                    {
+                                        if ( $varArrayValue == NULL )
+                                            $written = fwrite( $fp, "$varKey" . "[]$lineSeparator" );
+                                        else
+                                            $written = fwrite( $fp, "$varKey" . "[]=$varArrayValue$lineSeparator" );
+                                    }
+                                    if ( $written === false )
+                                        break;
+                                }
+                            }
+                            else
+                                $written = fwrite( $fp, "$varKey" . "[]$lineSeparator" );
+                        }
+                        else
+                        {
+                            $written = fwrite( $fp, "$varKey=$varValue$lineSeparator" );
+                        }
+                        if ( $written === false )
+                        {
+                            $writeOK = false;
+                            break;
+                        }
+                    }
+                    if ( !$writeOK )
+                        break;
+                    ++$i;
                 }
-                if ( !$writeOK )
-                    break;
-                ++$i;
             }
-        }
-        if ( $writeOK )
-        {
-            if ( $encapsulateInPHP )
+            if ( $writeOK )
             {
-                $written = fwrite( $fp, "*/ ?>" );
+                if ( $encapsulateInPHP )
+                {
+                    $written = fwrite( $fp, "*/ ?>" );
 
-                if ( $written === false )
-                    $writeOK = false;
+                    if ( $written === false )
+                        $writeOK = false;
+                }
             }
-        }
-        @fclose( $fp );
-        if ( !$writeOK )
-        {
-            unlink( $filePath );
-            return false;
+            @fclose( $fp );
+            if ( !$writeOK )
+            {
+                unlink( $filePath );
+                return false;
+            }
         }
 
         chmod( $filePath, self::$filePermission );
@@ -1120,6 +1155,309 @@ class eZINI
         return true;
     }
 
+    /**
+     * Creates an in-memory round-trip representation used to preserve comments and whitespace.
+     *
+     * @param string $contents
+     * @return array
+     */
+    protected function buildRoundTripData( $contents )
+    {
+        $lines = explode( "\n", $contents );
+        return array(
+            'lines' => $lines,
+            'parsed' => $this->parseRoundTripLines( $lines )
+        );
+    }
+
+    /**
+     * Attempts to generate a comment-preserving save output.
+     * Returns false if round-trip mode cannot be safely used.
+     *
+     * @param string $originalFilePath
+     * @param bool $onlyModified
+     * @param bool $resetArrays
+     * @return string|false
+     */
+    protected function buildRoundTripSaveContent( $originalFilePath, $onlyModified, $resetArrays )
+    {
+        if ( !$this->DirectAccess )
+            return false;
+
+        $normalizedPath = $this->normalizePathForRoundTrip( $originalFilePath );
+        if ( !isset( $this->RoundTripData[$normalizedPath] ) )
+        {
+            if ( !$this->loadRoundTripSourceFromFile( $normalizedPath ) )
+                return false;
+        }
+
+        $data = $this->RoundTripData[$normalizedPath];
+        $lines = $data['lines'];
+
+        // Remove deleted sections and settings when full save is requested.
+        if ( !$onlyModified )
+        {
+            $parsed = $this->parseRoundTripLines( $lines );
+            foreach ( array_keys( $parsed['sections'] ) as $sectionName )
+            {
+                if ( !isset( $this->BlockValues[$sectionName] ) )
+                {
+                    $sectionDef = $parsed['sections'][$sectionName];
+                    $length = $sectionDef['end'] - $sectionDef['start'] + 1;
+                    array_splice( $lines, $sectionDef['start'], $length );
+                    $parsed = $this->parseRoundTripLines( $lines );
+                }
+            }
+        }
+
+        foreach ( $this->BlockValues as $blockName => $blockVariables )
+        {
+            if ( $onlyModified && !$this->groupHasModifiedValues( $blockName ) )
+                continue;
+
+            $parsed = $this->parseRoundTripLines( $lines );
+            if ( !isset( $parsed['sections'][$blockName] ) )
+            {
+                $newSectionLines = array();
+                if ( !empty( $lines ) && end( $lines ) !== '' )
+                    $newSectionLines[] = '';
+                $newSectionLines[] = '[' . $blockName . ']';
+
+                foreach ( $blockVariables as $varKey => $varValue )
+                {
+                    if ( $onlyModified && !$this->isVariableModified( $blockName, $varKey ) )
+                        continue;
+                    foreach ( $this->variableToLines( $blockName, $varKey, $varValue, $resetArrays ) as $newLine )
+                    {
+                        $newSectionLines[] = $newLine;
+                    }
+                }
+
+                $lines = array_merge( $lines, $newSectionLines );
+                continue;
+            }
+
+            $sectionSettings = isset( $parsed['settings'][$blockName] ) ? $parsed['settings'][$blockName] : array();
+
+            if ( !$onlyModified )
+            {
+                foreach ( array_keys( $sectionSettings ) as $existingVarName )
+                {
+                    if ( !isset( $blockVariables[$existingVarName] ) )
+                    {
+                        $lineIndexes = $sectionSettings[$existingVarName];
+                        rsort( $lineIndexes );
+                        foreach ( $lineIndexes as $lineIndex )
+                        {
+                            array_splice( $lines, $lineIndex, 1 );
+                        }
+                        $parsed = $this->parseRoundTripLines( $lines );
+                        $sectionSettings = isset( $parsed['settings'][$blockName] ) ? $parsed['settings'][$blockName] : array();
+                    }
+                }
+            }
+
+            foreach ( $blockVariables as $varKey => $varValue )
+            {
+                if ( $onlyModified && !$this->isVariableModified( $blockName, $varKey ) )
+                    continue;
+
+                $newLines = $this->variableToLines( $blockName, $varKey, $varValue, $resetArrays );
+                $parsed = $this->parseRoundTripLines( $lines );
+                $sectionSettings = isset( $parsed['settings'][$blockName] ) ? $parsed['settings'][$blockName] : array();
+
+                if ( isset( $sectionSettings[$varKey] ) )
+                {
+                    $lineIndexes = $sectionSettings[$varKey];
+                    sort( $lineIndexes );
+                    $first = $lineIndexes[0];
+
+                    rsort( $lineIndexes );
+                    foreach ( $lineIndexes as $lineIndex )
+                    {
+                        array_splice( $lines, $lineIndex, 1 );
+                    }
+
+                    array_splice( $lines, $first, 0, $newLines );
+                }
+                else
+                {
+                    $insertAt = $parsed['sections'][$blockName]['end'] + 1;
+                    array_splice( $lines, $insertAt, 0, $newLines );
+                }
+            }
+        }
+
+        return implode( "\n", $lines );
+    }
+
+    /**
+     * Loads round-trip source data directly from disk for direct-access saves.
+     * This is needed when ini values were restored from cache and parseFile() did not run.
+     *
+     * @param string $normalizedPath
+     * @return bool
+     */
+    protected function loadRoundTripSourceFromFile( $normalizedPath )
+    {
+        if ( !$normalizedPath || !file_exists( $normalizedPath ) )
+            return false;
+
+        $contents = file_get_contents( $normalizedPath );
+        if ( $contents === false )
+            return false;
+
+        $contents = str_replace( "\r", '', $contents );
+        if ( $this->Codec )
+            $contents = $this->Codec->convertString( $contents );
+
+        $this->RoundTripData[$normalizedPath] = $this->buildRoundTripData( $contents );
+        return true;
+    }
+
+    /**
+     * Parses ini content lines into section and setting line indexes.
+     *
+     * @param array $lines
+     * @return array
+     */
+    protected function parseRoundTripLines( array $lines )
+    {
+        $sections = array();
+        $settings = array();
+        $currentBlock = '';
+        $lastSection = null;
+
+        foreach ( $lines as $index => $line )
+        {
+            if ( $line === '' || $line[0] === '#' )
+                continue;
+
+            $lineWithoutComment = $line;
+            if ( preg_match( "/^(.+)##.*/", $lineWithoutComment, $regs ) )
+                $lineWithoutComment = $regs[1];
+
+            if ( trim( $lineWithoutComment ) === '' )
+                continue;
+
+            if ( preg_match( "#^\[(.+)\]\s*$#", $lineWithoutComment, $newBlockNameArray ) )
+            {
+                if ( $lastSection !== null )
+                    $sections[$lastSection]['end'] = $index - 1;
+
+                $currentBlock = trim( $newBlockNameArray[1] );
+                $sections[$currentBlock] = array( 'start' => $index, 'end' => count( $lines ) - 1 );
+                $lastSection = $currentBlock;
+                continue;
+            }
+
+            if ( $currentBlock === '' )
+                continue;
+
+            if ( preg_match( "#^([\\w_*@-]+)\\[\\]$#", $lineWithoutComment, $valueArray ) )
+            {
+                $varName = trim( $valueArray[1] );
+                $settings[$currentBlock][$varName][] = $index;
+            }
+            else if ( preg_match( "#^([\\w_*@-]+)(\\[([^\\]]*)\\])?=(.*)$#", $lineWithoutComment, $valueArray ) )
+            {
+                $varName = trim( $valueArray[1] );
+                $settings[$currentBlock][$varName][] = $index;
+            }
+        }
+
+        return array(
+            'sections' => $sections,
+            'settings' => $settings
+        );
+    }
+
+    /**
+     * Normalizes paths for round-trip cache lookups.
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function normalizePathForRoundTrip( $path )
+    {
+        if ( $path === false || $path === null )
+            return '';
+
+        if ( strlen( $path ) > 0 && $path[0] !== '/' )
+        {
+            $path = __DIR__ . '/../../../' . $path;
+        }
+
+        $realPath = realpath( $path );
+        return $realPath !== false ? $realPath : $path;
+    }
+
+    /**
+     * Returns true if at least one variable in group is marked as modified.
+     *
+     * @param string $blockName
+     * @return bool
+     */
+    protected function groupHasModifiedValues( $blockName )
+    {
+        if ( !isset( $this->ModifiedBlockValues[$blockName] ) )
+            return false;
+
+        foreach ( $this->ModifiedBlockValues[$blockName] as $modifiedValue )
+        {
+            if ( $modifiedValue )
+                return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Serializes a variable to ini lines while reusing legacy save formatting.
+     *
+     * @param string $blockName
+     * @param string $varKey
+     * @param mixed $varValue
+     * @param bool $resetArrays
+     * @return array
+     */
+    protected function variableToLines( $blockName, $varKey, $varValue, $resetArrays )
+    {
+        $lines = array();
+        if ( is_array( $varValue ) )
+        {
+            if ( count( $varValue ) > 0 )
+            {
+                $customResetArray = ( isset( $this->BlockValues[$blockName]['ResetArrays'] ) and
+                                      $this->BlockValues[$blockName]['ResetArrays'] == 'false' )
+                                    ? true
+                                    : false;
+                if ( $resetArrays and !$customResetArray )
+                    $lines[] = $varKey . '[]';
+
+                foreach ( $varValue as $varArrayKey => $varArrayValue )
+                {
+                    if ( is_string( $varArrayKey ) )
+                        $lines[] = $varKey . '[' . $varArrayKey . ']=' . $varArrayValue;
+                    else if ( $varArrayValue == null )
+                        $lines[] = $varKey . '[]';
+                    else
+                        $lines[] = $varKey . '[]=' . $varArrayValue;
+                }
+            }
+            else
+            {
+                $lines[] = $varKey . '[]';
+            }
+        }
+        else
+        {
+            $lines[] = $varKey . '=' . $varValue;
+        }
+
+        return $lines;
+    }
+
     /*!
      Removes all read data from .ini files.
     */
@@ -1127,6 +1465,8 @@ class eZINI
     {
         $this->BlockValues = array();
         $this->ModifiedBlockValues = array();
+        $this->RoundTripData = array();
+        $this->LastParsedInputFiles = array();
     }
 
     /*!
@@ -2146,6 +2486,12 @@ class eZINI
 
     /// If \c true eZINI will check each setting (before saving) for correspondence of settings in site.ini[eZINISetting].ReadonlySettingList
     public $ReadOnlySettingsCheck = true;
+
+    /// Parsed round-trip data keyed by normalized absolute file path.
+    public $RoundTripData = array();
+
+    /// Last set of parsed input files for non-placement parse.
+    public $LastParsedInputFiles = array();
 
 }
 

--- a/tests/tests/lib/ezutils/ezini_test.php
+++ b/tests/tests/lib/ezutils/ezini_test.php
@@ -11,6 +11,245 @@
 class eZINITest extends ezpTestCase
 {
 
+    public function testSavePreservesCommentsInDirectAccessMode()
+    {
+        $rootPath = realpath( __DIR__ . '/../../../../' );
+        $tmpRelDir = 'var/tmp/ezini_roundtrip_' . uniqid( '', true );
+        $tmpDir = $rootPath . '/' . $tmpRelDir;
+        mkdir( $tmpDir, 0777, true );
+
+        $fileName = 'commented.ini.append.php';
+        $filePath = $tmpDir . '/' . $fileName;
+        $content = "<?php /* #?ini charset=\"utf8\"?\n\n"
+                 . "# top comment\n"
+                 . "[SiteSettings]\n"
+                 . "# keep this comment\n"
+                 . "SiteName=old ## inline explanation\n"
+                 . "SiteList[]=one\n"
+                 . "# keep section tail\n"
+                 . "*/ ?>";
+        file_put_contents( $filePath, $content );
+
+        $ini = new eZINI( $fileName, $tmpRelDir, null, false, false, true, false, true );
+        $ini->setVariable( 'SiteSettings', 'SiteName', 'new' );
+        $ini->setVariable( 'SiteSettings', 'SiteList', array( 'one', 'two' ) );
+
+        $this->assertTrue( $ini->save() );
+
+        $saved = file_get_contents( $filePath );
+        $this->assertStringContainsString( '# top comment', $saved );
+        $this->assertStringContainsString( '# keep this comment', $saved );
+        $this->assertStringContainsString( '# keep section tail', $saved );
+        $this->assertStringContainsString( 'SiteName=new', $saved );
+        $this->assertStringContainsString( 'SiteList[]=one', $saved );
+        $this->assertStringContainsString( 'SiteList[]=two', $saved );
+
+        $this->cleanupTmpDir( $tmpDir );
+    }
+
+    public function testSaveAppendsNewSettingWithoutDroppingComments()
+    {
+        $rootPath = realpath( __DIR__ . '/../../../../' );
+        $tmpRelDir = 'var/tmp/ezini_roundtrip_' . uniqid( '', true );
+        $tmpDir = $rootPath . '/' . $tmpRelDir;
+        mkdir( $tmpDir, 0777, true );
+
+        $fileName = 'append_comment.ini.append.php';
+        $filePath = $tmpDir . '/' . $fileName;
+        $content = "<?php /* #?ini charset=\"utf8\"?\n\n"
+                 . "# file intro\n"
+                 . "[SiteSettings]\n"
+                 . "SiteName=legacy\n"
+                 . "# comment between settings\n"
+                 . "*/ ?>";
+        file_put_contents( $filePath, $content );
+
+        $ini = new eZINI( $fileName, $tmpRelDir, null, false, false, true, false, true );
+        $ini->setVariable( 'SiteSettings', 'Additional', 'enabled' );
+
+        $this->assertTrue( $ini->save() );
+
+        $saved = file_get_contents( $filePath );
+        $this->assertStringContainsString( '# file intro', $saved );
+        $this->assertStringContainsString( '# comment between settings', $saved );
+        $this->assertStringContainsString( 'SiteName=legacy', $saved );
+        $this->assertStringContainsString( 'Additional=enabled', $saved );
+
+        $this->cleanupTmpDir( $tmpDir );
+    }
+
+    public function testSaveRemovesDeletedSettingAndKeepsSectionComments()
+    {
+        $rootPath = realpath( __DIR__ . '/../../../../' );
+        $tmpRelDir = 'var/tmp/ezini_roundtrip_' . uniqid( '', true );
+        $tmpDir = $rootPath . '/' . $tmpRelDir;
+        mkdir( $tmpDir, 0777, true );
+
+        $fileName = 'delete_comment.ini.append.php';
+        $filePath = $tmpDir . '/' . $fileName;
+        $content = "<?php /* #?ini charset=\"utf8\"?\n\n"
+                 . "[SiteSettings]\n"
+                 . "# survives rewrite\n"
+                 . "KeepMe=yes\n"
+                 . "DeleteMe=gone\n"
+                 . "*/ ?>";
+        file_put_contents( $filePath, $content );
+
+        $ini = new eZINI( $fileName, $tmpRelDir, null, false, false, true, false, true );
+        $ini->removeSetting( 'SiteSettings', 'DeleteMe' );
+
+        $this->assertTrue( $ini->save() );
+
+        $saved = file_get_contents( $filePath );
+        $this->assertStringContainsString( '# survives rewrite', $saved );
+        $this->assertStringContainsString( 'KeepMe=yes', $saved );
+        $this->assertStringNotContainsString( 'DeleteMe=gone', $saved );
+
+        $this->cleanupTmpDir( $tmpDir );
+    }
+
+    public function testSavePreservesCommentsWhenLoadedFromCache()
+    {
+        $rootPath = realpath( __DIR__ . '/../../../../' );
+        $tmpRelDir = 'var/tmp/ezini_roundtrip_' . uniqid( '', true );
+        $tmpDir = $rootPath . '/' . $tmpRelDir;
+        mkdir( $tmpDir, 0777, true );
+
+        $fileName = 'cached_roundtrip.ini.append.php';
+        $filePath = $tmpDir . '/' . $fileName;
+        $content = "<?php /* #?ini charset=\"utf8\"?\n\n"
+                 . "# cache path comment\n"
+                 . "[SiteSettings]\n"
+                 . "SiteName=old\n"
+                 . "*/ ?>";
+        file_put_contents( $filePath, $content );
+
+        // First load warms up ini cache for this file.
+        $iniWarmup = new eZINI( $fileName, $tmpRelDir, null, true, false, true, false, true );
+        $this->assertEquals( 'old', $iniWarmup->variable( 'SiteSettings', 'SiteName' ) );
+
+        // New instance should be able to preserve comments even if values are restored from cache.
+        $ini = new eZINI( $fileName, $tmpRelDir, null, true, false, true, false, true );
+        $ini->setVariable( 'SiteSettings', 'SiteName', 'new' );
+
+        $this->assertTrue( $ini->save() );
+
+        $saved = file_get_contents( $filePath );
+        $this->assertStringContainsString( '# cache path comment', $saved );
+        $this->assertStringContainsString( 'SiteName=new', $saved );
+
+        $this->cleanupTmpDir( $tmpDir );
+    }
+
+    public function testSaveRetainsRealSiteIniStructureWhenUpdatingExtensions()
+    {
+        $rootPath = realpath( __DIR__ . '/../../../../' );
+        $tmpRelDir = 'var/tmp/ezini_roundtrip_' . uniqid( '', true );
+        $tmpDir = $rootPath . '/' . $tmpRelDir;
+        mkdir( $tmpDir, 0777, true );
+
+        $fileName = 'site.ini.append.php';
+        $filePath = $tmpDir . '/' . $fileName;
+        $content = "<?php /* #?ini charset=\"utf-8\"?\n\n"
+                 . "[DebugSettings]\n"
+                 . "#DebugOutput=enabled\n\n"
+                 . "[TemplateSettings]\n"
+                 . "#ShowUsedTemplates=enabled\n\n"
+                 . "[FileSettings]\n"
+                 . "AllowedDeletionDirs[]=/var/www/vhosts/alpha.se7enx.com/doc/alpha.se7enx.com/var\n"
+                 . "VarDir=var/site\n\n"
+                 . "[ExtensionSettings]\n"
+                 . "ActiveExtensions[]=ezjscore\n"
+                 . "ActiveExtensions[]=ezoe\n"
+                 . "ActiveExtensions[]=ezformtoken\n"
+                 . "ActiveExtensions[]=ezwt\n\n"
+                 . "[SiteSettings]\n"
+                 . "DefaultAccess=sevenx_site_user\n"
+                 . "SiteList[]=sevenx_site_user\n"
+                 . "SiteList[]=sevenx_site_admin\n"
+                 . "RootNodeDepth=1\n\n"
+                 . "[MailSettings]\n"
+                 . "Transport=sendmail\n"
+                 . "AdminEmail=info@se7enx.com\n"
+                 . "EmailSender=\n"
+                 . "*/ ?>";
+        file_put_contents( $filePath, $content );
+
+        $ini = new eZINI( 'site.ini.append', $tmpRelDir, null, true, false, true, false, true );
+        $selectedExtensions = $ini->variable( 'ExtensionSettings', 'ActiveExtensions' );
+        $toSave = array_unique( array_merge( $selectedExtensions, array( 'nxc_powercontent' ) ) );
+
+        $ini->setVariable( 'ExtensionSettings', 'ActiveExtensions', $toSave );
+        $this->assertTrue( $ini->save( 'site.ini.append', '.php', false, false ) );
+
+        $saved = file_get_contents( $filePath );
+        $this->assertStringContainsString( '[DebugSettings]', $saved );
+        $this->assertStringContainsString( '#DebugOutput=enabled', $saved );
+        $this->assertStringContainsString( '[TemplateSettings]', $saved );
+        $this->assertStringContainsString( '#ShowUsedTemplates=enabled', $saved );
+        $this->assertStringContainsString( 'ActiveExtensions[]=nxc_powercontent', $saved );
+        $this->assertStringContainsString( '[SiteSettings]', $saved );
+        $this->assertStringContainsString( 'EmailSender=', $saved );
+        $this->assertStringContainsString( '*/ ?>', $saved );
+
+        $this->cleanupTmpDir( $tmpDir );
+    }
+
+    public function testSaveRetainsCurrentSiteIniAppendOutsideExtensionSettings()
+    {
+        $rootPath = realpath( __DIR__ . '/../../../../' );
+        $sourcePath = $rootPath . '/settings/override/site.ini.append.php';
+        $this->assertFileExists( $sourcePath );
+
+        $tmpRelDir = 'var/tmp/ezini_roundtrip_' . uniqid( '', true );
+        $tmpDir = $rootPath . '/' . $tmpRelDir;
+        mkdir( $tmpDir, 0777, true );
+
+        $tmpPath = $tmpDir . '/site.ini.append.php';
+        copy( $sourcePath, $tmpPath );
+
+        $before = file_get_contents( $tmpPath );
+
+        $ini = new eZINI( 'site.ini.append', $tmpRelDir, null, true, false, true, false, true );
+        $selectedExtensions = $ini->variable( 'ExtensionSettings', 'ActiveExtensions' );
+        $toSave = array_unique( array_merge( $selectedExtensions, array( 'test_roundtrip_extension' ) ) );
+
+        $ini->setVariable( 'ExtensionSettings', 'ActiveExtensions', $toSave );
+        $this->assertTrue( $ini->save( 'site.ini.append', '.php', false, false ) );
+
+        $after = file_get_contents( $tmpPath );
+        $beforeWithoutExtensions = $this->stripExtensionSettingsBody( $before );
+        $afterWithoutExtensions = $this->stripExtensionSettingsBody( $after );
+
+        $this->assertSame( $beforeWithoutExtensions, $afterWithoutExtensions );
+        $this->assertStringContainsString( 'ActiveExtensions[]=test_roundtrip_extension', $after );
+
+        $this->cleanupTmpDir( $tmpDir );
+    }
+
+    private function stripExtensionSettingsBody( $contents )
+    {
+        return preg_replace(
+            '/(\[ExtensionSettings\]\n)(.*?)(?=\n\[[^\]]+\]|\n\*\/ \?>|\z)/s',
+            '$1<EXTENSION_SETTINGS_BODY>',
+            $contents
+        );
+    }
+
+    private function cleanupTmpDir( $tmpDir )
+    {
+        if ( !is_dir( $tmpDir ) )
+            return;
+
+        foreach ( glob( $tmpDir . '/*' ) as $tmpFile )
+        {
+            if ( is_file( $tmpFile ) )
+                unlink( $tmpFile );
+        }
+
+        rmdir( $tmpDir );
+    }
+
     /**
      * Test to make sure default override dirs only contain 'override' folder
      */
@@ -107,6 +346,14 @@ class eZINITest extends ezpTestCase
         self::assertEquals( 0, count( $overrideDirs['sa-extension'] ), 'There should have been 0 override dirs in sa-extension scope.' );
         self::assertTrue( $success, '$ini->removeOverrideDir( \'extension:ext1\', \'sa-extension\' ) should have been returned true as identifier does exist.' );
         self::assertFalse( $failed, '$ini->removeOverrideDir( \'extension:ext8\' ) should have been returned false as identifier does not exist.' );
+    }
+}
+
+// Compatibility alias for PHPUnit runners that infer class names from *_test.php filenames.
+if ( !class_exists( 'ezini_test', false ) )
+{
+    class ezini_test extends eZINITest
+    {
     }
 }
 


### PR DESCRIPTION
…nd docs.

Hello Community!

Ever been cautious about using settings write features of eZINI based solutions? Were you upset that INI file comment statements were traditionally lost due to limitations of this part of the software.

That changes today! Today 7x introduces a simple documented patch to the eZINI PHP Class which does the heavy lifting to preserve INI file comments regardless of the way you happen to use eZINI solutions.

Cheers,
7x